### PR TITLE
Fix reconnect issue

### DIFF
--- a/lib/Mojo/Discord/Gateway.pm
+++ b/lib/Mojo/Discord/Gateway.pm
@@ -56,6 +56,7 @@ my %no_resume = (
     '1009' => 'Message Too Big',
     '1011' => 'Internal Server Err',
     '1012' => 'Service Restart',
+    '4003' => 'Not Authenticated',
     '4007' => 'Invalid Sequence',
     '4009' => 'Session Timeout',
     '4010' => 'Invalid Shard'
@@ -284,7 +285,7 @@ sub on_finish
         say localtime(time) . " (on_finish) \$tx is unexpectedly undefined.";
         die("\$tx is not defined. Cannot recover automatically.");
     }
-    else
+    elsif (!$tx->is_finished)
     {
         $tx->finish;
     }


### PR DESCRIPTION
The reconnection ends up in a bad loop if the transaction is already
finished, causing $tx->finish to throw an error.

Sun Mar  3 10:55:22 2019 OP 1 SEQ 293 HEARTBEAT
Sun Mar  3 10:55:22 2019 (send_op) Failed heartbeat check. Closing connection with Code 4009: Heartbeat Failure
Sun Mar  3 10:55:22 2019 (on_finish) Websocket Connection Closed with Code 4009 (Timeout: Heartbeat Failure)
Mojo::Reactor::Poll: Timer failed: Can't call method "write" on an undefined value at lib/perl5/Mojo/UserAgent.pm line 351.


Also, 4003 is needed in the no_resume list.