### PR TITLE
Fix status_update()

### DIFF
--- a/lib/Mojo/Discord/Gateway.pm
+++ b/lib/Mojo/Discord/Gateway.pm
@@ -161,12 +161,16 @@ sub status_update
 {
     my ($self, $param) = @_;
 
-    my $idle = $param->{'idle_since'} if defined $param->{'idle_since'};
+    my $idle = $param->{'since'} if defined $param->{'since'};
     my $game = $param->{'game'} if defined $param->{'game'};
     my $op = 3;
     my $d = {};
-    $d->{'idle_since'} = ( defined $idle ? $idle : undef );
+    $d->{'since'} = ( defined $idle ? $idle : undef );
     $d->{'game'}{'name'} = $game if defined $game;
+    $d->{'game'}{'type'} = 0 if defined $game;
+    $d->{'status'} = 'online';
+    $d->{'afk'} = \0;
+
     $self->send_op($op, $d);
 }
 


### PR DESCRIPTION
In master it is already working but not in moo. Also I'm setting the type to 0 because the variable is named game (easier to set in the client when you can just omit it). Now with the rich presence stuff there is way more possible now (activity-object). I might work on that later.