### PR TITLE
Make 1006 (Abnormal Closure) initiate a new session

### DIFF
--- a/lib/Mojo/Discord/Gateway.pm
+++ b/lib/Mojo/Discord/Gateway.pm
@@ -98,6 +98,7 @@ has no_resume => ( is => 'ro', default => sub {
     {
         '1000' => 'Normal Closure',
         '1001' => 'Going Away',
+        '1006' => 'Abnormal Closure',
         '1009' => 'Message Too Big',
         '1011' => 'Internal Server Err',
         '1012' => 'Service Restart',


### PR DESCRIPTION
It is better to initiate a new when we are not sure what happened.

Currently after a 1006 my bot get stuck in a loop:
```
[2020-05-12 20:59:23.63446] [264297] [info] [Discord.pm] [init] New session beginning Tue May 12 20:59:23 2020
[2020-05-12 20:59:23.99561] [264297] [info] [Gateway.pm] [gw_connect] WebSocket Connection Established
[2020-05-12 20:59:24.18378] [264297] [info] [Gateway.pm] [dispatch_ready] Discord gateway is ready
[2020-05-12 22:20:28.69310] [264297] [info] [Gateway.pm] [on_finish] Websocket connection closed with Code $code = 1006;
 (Abnormal Closure)
[2020-05-12 22:20:28.69323] [264297] [info] [Gateway.pm] [reconnect] Reconnecting and resuming previous session.
[2020-05-12 22:20:39.04046] [264297] [info] [Gateway.pm] [gw_connect] WebSocket Connection Established
[2020-05-12 22:44:58.00656] [264297] [warn] [Gateway.pm] [handle_event] Unhandled Event: OP 7
[2020-05-12 22:45:08.00773] [264297] [info] [Gateway.pm] [on_finish] Websocket connection closed with Code $code = 1001;
 (Discord WebSocket requesting client reconnect.)
[2020-05-12 22:45:08.00789] [264297] [info] [Gateway.pm] [reconnect] Reconnecting and starting a new session.
[2020-05-12 22:45:28.31211] [264297] [info] [Gateway.pm] [gw_connect] WebSocket Connection Established
[2020-05-12 22:45:28.54122] [264297] [info] [Gateway.pm] [dispatch_ready] Discord gateway is ready
[2020-05-13 00:33:08.51962] [264297] [warn] [Gateway.pm] [handle_event] Unhandled Event: OP 7
[2020-05-13 00:33:18.52111] [264297] [info] [Gateway.pm] [on_finish] Websocket connection closed with Code $code = 1001;
 (Discord WebSocket requesting client reconnect.)
[Repeating forever]
```