### PR TITLE
discordapp.com -> discord.com

### DIFF
--- a/lib/Mojo/Discord.pm
+++ b/lib/Mojo/Discord.pm
@@ -19,7 +19,7 @@ has name        => ( is => 'ro' );
 has url         => ( is => 'ro' );
 has version     => ( is => 'ro' );
 has reconnect   => ( is => 'ro' );
-has base_url    => ( is => 'rw', default => 'https://discordapp.com/api' );
+has base_url    => ( is => 'rw', default => 'https://discord.com/api' );
 has gw          => ( is => 'lazy', builder => sub {
                     my $self = shift;
                     Mojo::Discord::Gateway->new(
@@ -382,7 +382,7 @@ $bot->start();
 
 =head1 DESCRIPTION
 
-L<Mojo::Discord> is a L<Mojo::UserAgent> based L<Discord|https://discordapp.com> API library designed for creating bots (including user-bots). A Discord User or Bot Token is required.
+L<Mojo::Discord> is a L<Mojo::UserAgent> based L<Discord|https://discord.com> API library designed for creating bots (including user-bots). A Discord User or Bot Token is required.
 
 The Discord API is divided into four main parts: OAuth, REST, Gateway, and Guild. The main module is a wrapper that allows you to use the REST and Gateway modules together as part of a single object.
 

--- a/lib/Mojo/Discord/Auth.pm
+++ b/lib/Mojo/Discord/Auth.pm
@@ -27,7 +27,7 @@ has version             => ( is => 'ro', required => 1 );
 has code                => ( is => 'rw' );
 has refresh_token       => ( is => 'ro' );
 has verbose             => ( is => 'rw' );
-has base_url            => ( is => 'ro', default => 'https://discordapp.com/api' );
+has base_url            => ( is => 'ro', default => 'https://discord.com/api' );
 has token_url           => ( is => 'ro', default => sub { shift->base_url . '/oauth2/token' } );
 has agent               => ( is => 'rw' );
 has grant_type          => ( is => 'rw', default => sub { defined shift->code? 'authorization_code' : 'refresh_token' } );

--- a/lib/Mojo/Discord/Gateway.pm
+++ b/lib/Mojo/Discord/Gateway.pm
@@ -124,7 +124,7 @@ has tx                  => ( is => 'rw' );
 has heartbeat_interval  => ( is => 'rw' );
 has heartbeat_loop      => ( is => 'rw' );
 has heartbeat           => ( is => 'rw', default => 2 );
-has base_url            => ( is => 'ro', default => 'https://discordapp.com/api' );
+has base_url            => ( is => 'ro', default => 'https://discord.com/api' );
 has gateway_url         => ( is => 'rw', default => sub { shift->base_url . '/gateway' });
 has gateway_version     => ( is => 'ro', default => 6 );
 has gateway_encoding    => ( is => 'ro', default => 'json' );

--- a/lib/Mojo/Discord/REST.pm
+++ b/lib/Mojo/Discord/REST.pm
@@ -19,7 +19,7 @@ has 'token'         => ( is => 'ro' );
 has 'name'          => ( is => 'rw', required => 1 );
 has 'url'           => ( is => 'rw', required => 1 );
 has 'version'       => ( is => 'ro', required => 1 );
-has 'base_url'      => ( is => 'ro', default => 'https://discordapp.com/api' );
+has 'base_url'      => ( is => 'ro', default => 'https://discord.com/api' );
 has 'agent'         => ( is => 'lazy', builder => sub { my $self = shift; return $self->name . ' (' . $self->url . ',' . $self->version . ')' } );
 has 'ua'            => ( is => 'lazy', builder => sub 
                         { 


### PR DESCRIPTION
Change all discordapp.com domains to discord.com

```
May the 4th be with you :BabyYodaSip:  Discord has finally made the switch to discord.com :tada:

With this change also means that the API endpoint is moving too! Please start moving your libraries, webhooks, and integrations over to using discord.com in place of discordapp.com.

We currently plan to start requiring the new domain later this year for third party developers on November 7th, 2020. We will be sending out more formal notices (system DMs and account emails) to announce this breaking change in the coming weeks.
```